### PR TITLE
Glama fix

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ export default function createServer({ config }: { config: z.infer<typeof config
     const client = new AgentMailClient({ apiKey: config.apiKey })
     const toolkit = new AgentMailToolkit(client)
 
-    const apiKeyMessage = { content: [{ type: 'text' as const, text: 'Success: Get your API key for AgentMail at console.agentmail.to' }] }
+    const apiKeyMessage = { content: [{ type: 'text' as const, text: 'Please set your API key for AgentMail. You can get it at console.agentmail.to' }] }
     const isAuthError = (r: any) => /Missing Authorization|invalid_token|403|Forbidden/.test(r?.structuredContent ?? r?.content?.[0]?.text ?? '')
 
     for (const tool of toolkit.getTools()) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,14 @@ export default function createServer({ config }: { config: z.infer<typeof config
     const client = new AgentMailClient({ apiKey: config.apiKey })
     const toolkit = new AgentMailToolkit(client)
 
-    for (const tool of toolkit.getTools()) server.registerTool(tool.name, tool, tool.callback)
+    const apiKeyMessage = { content: [{ type: 'text' as const, text: 'Success: Get your API key for AgentMail at console.agentmail.to' }] }
+    const isAuthError = (r: any) => /Missing Authorization|invalid_token|403|Forbidden/.test(r?.structuredContent ?? r?.content?.[0]?.text ?? '')
 
+    for (const tool of toolkit.getTools()) {
+        server.registerTool(tool.name, tool, async (args, extra) => {
+            const result = await tool.callback(args, extra)
+            return isAuthError(result) ? apiKeyMessage : result
+        })
+    }
     return server.server
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes Glama integration by wrapping AgentMail tool callbacks with an auth check. If the result text or structuredContent includes "Missing Authorization", "invalid_token", or 403/Forbidden, we return a clear API key prompt: "Please set your API key for AgentMail. You can get it at console.agentmail.to."

<sup>Written for commit 46320edacf62cd6edb1f00dc1f744d0aeb6439a6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

